### PR TITLE
Do not require a "self" argument to deprecated functions

### DIFF
--- a/src/zope/deprecation/deprecation.py
+++ b/src/zope/deprecation/deprecation.py
@@ -161,10 +161,10 @@ class DeprecatedGetSetDeleteProperty(DeprecatedGetSetProperty):
 
 def DeprecatedMethod(method, message):
 
-    def deprecated_method(self, *args, **kw):
+    def deprecated_method(*args, **kw):
         if __show__():
             warnings.warn(message, DeprecationWarning, 2)
-        return method(self, *args, **kw)
+        return method(*args, **kw)
 
     return deprecated_method
 

--- a/src/zope/deprecation/tests.py
+++ b/src/zope/deprecation/tests.py
@@ -366,7 +366,7 @@ class Test_deprecated(WarningsSetupBase, unittest.TestCase):
         result = self._callFUT(functionfixture, 'hello')
         self.assertNotEqual(result, functionfixture)
         self.assertEqual(self.warnings.w, [])
-        result(self)
+        result()
         self.assertEqual(
             self.warnings.w,
             [('hello', DeprecationWarning, 2)])
@@ -422,7 +422,7 @@ class Test_deprecate(WarningsSetupBase, unittest.TestCase):
     def test___call__(self):
         proxy = self._makeOne('hello')
         result = proxy(functionfixture)
-        self.assertEqual(result(self), None)
+        self.assertEqual(result(), None)
         self.assertEqual(
             self.warnings.w,
             [('hello', DeprecationWarning, 2)])
@@ -502,4 +502,4 @@ class ClassFixture(object): pass
 
 class ClassFixture2(object): pass
 
-def functionfixture(self): pass
+def functionfixture(): pass


### PR DESCRIPTION
Calling a deprecated function which takes no arguments will raise the following exception:

> TypeError: deprecated_method() takes at least 1 argument (0 given)

It looks as if a few stray `self`s were left over from a past refactoring. This branch fixes it and updates the test suite accordingly.
