### PR TITLE
Add OSI license classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     keywords=["deprecation", "deprecated", "warning"],
     classifiers=[
         "Intended Audience :: Developers",
+        "License :: OSI Approved :: Zope Public License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
To be consistent with other zope projects like https://github.com/zopefoundation/zope.dottedname/blob/master/setup.py

It will be also helpful for those using https://github.com/pivotal/LicenseFinder as it detects the license as `unknown`, while it detects properly `Zope Public License` for zope.dottedname and zope.interface.