### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  ``zope.deprecation`` Changelog
 ================================
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-01-15)

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setup(
     name='zope.deprecation',
     version='6.0.dev0',
     url='https://github.com/zopefoundation/zope.deprecation',
-    license='ZPL 2.1',
+    license='ZPL-2.1',
     description='Zope Deprecation Infrastructure',
-    author='Zope Corporation and Contributors',
-    author_email='zope-dev@zope.org',
+    author='Zope Foundation and Contributors',
+    author_email='zope-dev@zope.dev',
     long_description=(
         read('README.rst')
         + '\n\n' +

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -58,9 +57,6 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Framework :: Zope :: 3",
     ],
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-    namespace_packages=['zope', ],
     python_requires='>= 3.9',
     install_requires=[
         'setuptools',
@@ -70,7 +66,7 @@ setup(
     extras_require={
         'docs': ['Sphinx'],
         'test': [
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def read(*rnames):
 
 setup(
     name='zope.deprecation',
-    version='5.2.dev0',
+    version='6.0.dev0',
     url='https://github.com/zopefoundation/zope.deprecation',
     license='ZPL 2.1',
     description='Zope Deprecation Infrastructure',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
